### PR TITLE
Fix trait tag text color overridden in PF2e chat cards

### DIFF
--- a/styles/chatcard.css
+++ b/styles/chatcard.css
@@ -26,7 +26,7 @@
 }
 
 .chat-message.card-style-message .message-content,
-.chat-message.card-style-message .message-content * {
+.chat-message.card-style-message .message-content *:not(.tag) {
     color: inherit;
 }
 
@@ -55,7 +55,7 @@
 }
 
 .chat-message .message-content,
-.chat-message .message-content * {
+.chat-message .message-content *:not(.tag) {
     color: inherit;
 }
 


### PR DESCRIPTION
The wildcard color: inherit rule was overriding PF2e's trait tag colors, causing tag text to render as black and become unreadable. Excluded .tags containers from the color inheritance rule so PF2e trait pills render with their intended colors.

Before: 
<img width="298" height="186" alt="lczHTv6A0J" src="https://github.com/user-attachments/assets/866e1d22-bb9a-4858-94de-eb86714e8bcc" />

After:
<img width="293" height="215" alt="image" src="https://github.com/user-attachments/assets/72a9927f-a657-4455-8056-110585f507a1" />
